### PR TITLE
Generic cinm.op.reduce

### DIFF
--- a/cinnamon/include/cinm-mlir/Dialect/Cinm/IR/CinmOps.td
+++ b/cinnamon/include/cinm-mlir/Dialect/Cinm/IR/CinmOps.td
@@ -218,28 +218,44 @@ def Cinm_ScanOp : Cinm_Op<"op.scan", [SameOperandsAndResultType, Pure]> {
 }
 
 def Cinm_ReduceOp : Cinm_Op<"op.reduce",
-    [Pure, TypeMatchesElementType<"result", "input">,
-    DeclareOpInterfaceMethods<CinmTilingInterface>]> {
+    [Pure, DeclareOpInterfaceMethods<CinmTilingInterface>]> {
   let summary = "Reduce the tensor according to a given binary operator.";
 
   let description = [{
+    Add a dimension using the `dimensions` attribute. For now, only 1 reduction
+    dimension is allowed. Can be negative to index from the end. Default value
+    is -1 (last dim). 0-ranked result gets converted to scalar value. Example:
 
+    ```
+    %r = cinm.compute attributes { workgroupShape = array<i64: 1,8,16> } -> tensor<288xf32> {
+        // Simple vector to scalar: tensor<100xf32> -> f32
+        %reduced_vec = cinm.op.reduce min (%vec) : tensor<100xf32> -> f32
+        // Default: reduction dimension = -1 -> last dim -> on a 2D tensor, dim = 1
+        %max_along_dim1_a = cinm.op.reduce max (%x) : tensor<288x512xf32> -> tensor<288xf32>
+        // Equivalent
+        %max_along_dim1_b = cinm.op.reduce max (%x) { dimensions = array<i64: 1> } : tensor<288x512xf32> -> tensor<288xf32>
+        // Different dimension yields different result type tensor<512xf32>
+        %add_along_dim0 = cinm.op.reduce add (%x) { dimensions = array<i64: 0> } : tensor<288x512xf32> -> tensor<512xf32>
+        cinm.yield %max_along_dim1_a : tensor<288xf32>
+    }
+    ```
   }];
 
   let arguments = (ins
     Cinm_ReduceMethodAttr:$method,
-    AnyRankedTensor:$input
+    AnyNon0RankedTensor:$input,
+    DefaultValuedAttr<DenseI64ArrayAttr, "{-1}">:$dimensions
   );
 
   let results = (
     outs
-    AnyScalar:$result
+    AnyType:$result
   );
 
   let extraClassDeclaration = [{
   }];
 
-  let assemblyFormat = "$method `(` $input `)` attr-dict `:` type($input)";
+  let assemblyFormat = "$method `(` $input `)` attr-dict `:` type($input) `->` type($result)";
 }
 
 def Cinm_TopKOp : Cinm_Op<"op.topK", [InferShapedTypeOpAdaptor, Pure]> {

--- a/cinnamon/include/cinm-mlir/Dialect/Cinm/Interfaces/TilingInterface.h
+++ b/cinnamon/include/cinm-mlir/Dialect/Cinm/Interfaces/TilingInterface.h
@@ -10,9 +10,7 @@
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Location.h>
 #include <mlir/IR/Value.h>
-#include <mlir/IR/ValueRange.h>
 #include <mlir/Support/LLVM.h>
-#include <mlir/Support/LogicalResult.h>
 #include <optional>
 #include <utility>
 
@@ -20,16 +18,16 @@ namespace mlir::cinm {
 struct ComputeOp;
 struct TilingParameters {
   /// Workgroup shape being considered for tiling.
-  const llvm::ArrayRef<int64_t> workgroupShape;
+  const ArrayRef<int64_t> workgroupShape;
   /// Sizes of the different buffer levels.
   /// Buffers at one level are shared with later levels.
   /// For instance for a workgroup with shape {A,B,C}
   /// and buffer sizes {M,N,P}, the space available
   /// for each compute leaf is P + N/C + M/B/C.
-  const llvm::ArrayRef<int64_t> bufferSizesInBytes;
+  const ArrayRef<int64_t> bufferSizesInBytes;
 
-  TilingParameters(llvm::ArrayRef<int64_t> bufferSizesInBytes,
-                   llvm::ArrayRef<int64_t> workgroupShape)
+  TilingParameters(ArrayRef<int64_t> bufferSizesInBytes,
+                   ArrayRef<int64_t> workgroupShape)
       : workgroupShape(workgroupShape),
         bufferSizesInBytes(bufferSizesInBytes) {}
 
@@ -70,13 +68,13 @@ using ReduceAccumulatorCallback =
 
 template <typename ReductionOp>
 Value createVectorReduce(OpBuilder &builder, Location loc, Value vector,
-                         Value init, int64_t clusterSize) {
+                         Value init, DenseI64ArrayAttr dims, int64_t clusterSize) {
   return createVectorReduce(
       builder, loc, vector, init,
       [](OpBuilder &builder, Location loc, Value lhs, Value rhs) {
         return builder.create<ReductionOp>(loc, lhs, rhs);
       },
-      clusterSize);
+      dims, clusterSize);
 }
 
 template <typename IntOp, typename FloatOp>
@@ -105,19 +103,19 @@ inline Value createArithMul(OpBuilder &builder, Location loc, Value a,
 
 Value createVectorReduce(OpBuilder &builder, Location loc, Value vector,
                          Value init, ReduceAccumulatorCallback callback,
-                         int64_t clusterSize = 1);
+                         DenseI64ArrayAttr dims, int64_t clusterSize = 1);
 
 Value createVectorReduceAdd(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize = 1);
+                            DenseI64ArrayAttr dims, int64_t clusterSize = 1);
 
 Value createVectorReduceMul(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize = 1);
+                            DenseI64ArrayAttr dims, int64_t clusterSize = 1);
 
 Value createVectorReduceMin(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize = 1);
+                            DenseI64ArrayAttr dims, int64_t clusterSize = 1);
 
 Value createVectorReduceMax(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize = 1);
+                            DenseI64ArrayAttr dims, int64_t clusterSize = 1);
 
 } // namespace mlir::cinm
 

--- a/cinnamon/include/cinm-mlir/Dialect/Cinm/Transforms/Passes.td
+++ b/cinnamon/include/cinm-mlir/Dialect/Cinm/Transforms/Passes.td
@@ -13,11 +13,6 @@ def CinmTilingPass: Pass<"cinm-tiling"> {
   let summary = "Applys tiling to all operations implementing the cinm tiling interface";
   let description = [{}];
 
-  let options = [
-    Option<"reductionTileSize", "reduction-tile-size", "uint64_t", /*default=*/"32",
-           "Set size of batches for reduction loop (default: 32)">
-  ];
-
   let dependentDialects = [
     "mlir::LLVM::LLVMDialect",
     "mlir::affine::AffineDialect",

--- a/cinnamon/lib/Dialect/Cinm/IR/CinmTilingImplementations.cpp
+++ b/cinnamon/lib/Dialect/Cinm/IR/CinmTilingImplementations.cpp
@@ -1,5 +1,3 @@
-
-
 #include "cinm-mlir/Conversion/CommonPatterns.h"
 #include "cinm-mlir/Dialect/Cinm/IR/CinmAttributes.h"
 #include "cinm-mlir/Dialect/Cinm/IR/CinmOps.h"
@@ -10,18 +8,15 @@
 #include <llvm/ADT/ArrayRef.h>
 #include <llvm/ADT/SmallVector.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
-#include <mlir/Dialect/Linalg/IR/Linalg.h>
 #include <mlir/Dialect/MemRef/IR/MemRef.h>
 #include <mlir/Dialect/Tensor/IR/Tensor.h>
 #include <mlir/IR/AffineExpr.h>
-#include <mlir/IR/AffineMap.h>
 #include <mlir/IR/Builders.h>
 #include <mlir/IR/BuiltinTypeInterfaces.h>
 #include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/Diagnostics.h>
 #include <mlir/IR/ImplicitLocOpBuilder.h>
 #include <mlir/IR/ValueRange.h>
-#include <type_traits>
 
 using namespace mlir;
 using namespace mlir::cinm;
@@ -38,16 +33,16 @@ TilingResult2 ReduceOp::convertToTiledOps(OpBuilder &builder,
   auto method = getMethod();
   if (method == ReduceMethod::ADD) {
     return TilingResult2({createVectorReduceAdd(builder, getLoc(), getOperand(),
-                                                reduceClusterSize)});
+                                                getDimensionsAttr(), reduceClusterSize)});
   } else if (method == ReduceMethod::MUL) {
     return TilingResult2({createVectorReduceMul(builder, getLoc(), getOperand(),
-                                                reduceClusterSize)});
+                                                getDimensionsAttr(), reduceClusterSize)});
   } else if (method == ReduceMethod::MAX) {
     return TilingResult2({createVectorReduceMax(builder, getLoc(), getOperand(),
-                                                reduceClusterSize)});
+                                                getDimensionsAttr(), reduceClusterSize)});
   } else if (method == ReduceMethod::MIN) {
     return TilingResult2({createVectorReduceMin(builder, getLoc(), getOperand(),
-                                                reduceClusterSize)});
+                                                getDimensionsAttr(), reduceClusterSize)});
   } else {
     abort();
   }

--- a/cinnamon/lib/Dialect/Cinm/Interfaces/TilingInterface.cpp
+++ b/cinnamon/lib/Dialect/Cinm/Interfaces/TilingInterface.cpp
@@ -153,65 +153,164 @@ Value reshapeStatic(OpBuilder &builder, Location loc, Value value,
   assert(false && "not handled for memrefs for now");
 }
 
-Value createVectorReduce(OpBuilder &builder, Location loc, Value vector,
-                         Value init, ReduceAccumulatorCallback callback,
-                         int64_t clusterSize) {
-  const auto vectorType = cast<RankedTensorType>(vector.getType());
-  assert(vectorType.getRank() == 1);
-  const int64_t vectorSize = vectorType.getDimSize(0);
-  const Type elementType = vectorType.getElementType();
+linalg::ReduceOp makeReduceOp(OpBuilder &builder, Location loc, Value input, Value init,
+                              int64_t dim, ReduceAccumulatorCallback callback) {
+    return builder.create<linalg::ReduceOp>(
+        loc, ValueRange{input}, ValueRange{init}, SmallVector{dim},
+        [&](OpBuilder &builder, Location loc, ValueRange args) {
+          const Value result = callback(builder, loc, args[0], args[1]);
+          builder.create<linalg::YieldOp>(loc, result);
+        });
+}
 
-  const Value initTensor = builder.create<tensor::FromElementsOp>(
-      loc, RankedTensorType::get({}, elementType), ValueRange{init});
-  const Value clusterSizeConst =
+/// This should probably some util function somewhere.
+Value createMLIRValueFromArrayRef(OpBuilder &builder, Location loc, ArrayRef<int64_t> array) {
+    // Define the element type and shape
+    auto elementType = builder.getIntegerType(64);
+    auto tensorType = RankedTensorType::get({static_cast<int64_t>(array.size())}, elementType);
+
+    // Create a DenseElementsAttr with the ArrayRef data
+    auto denseAttr = DenseElementsAttr::get(tensorType, array);
+
+    // Create a constant operation to hold the value
+    return builder.create<arith::ConstantOp>(loc, tensorType, denseAttr);
+}
+
+Value createVectorReduce(OpBuilder &builder, Location loc, Value inputTensor,
+                         Value init, ReduceAccumulatorCallback callback,
+                         DenseI64ArrayAttr dims, int64_t clusterSize) {
+    const auto vectorType = cast<RankedTensorType>(inputTensor.getType());
+    assert(dims.size() == 1 && "more than 1 reduction dim is not (yet) supported");
+    if (dims.size() != 1) {
+      emitError(loc, "More than 1 reduction dimension is not (yet) supported");
+    }
+    int64_t dim = dims[0];
+    if (dim < 0) {
+      if (dim < -vectorType.getRank()) {
+        emitError(loc, "Negative reduction dim (" + std::to_string(dim) + ") must be in [-input rank, 0)");
+        assert(false && "negative dim must be in [-input rank, 0)");
+      }
+      // Indexing from back, e.g. dim=-1 -> rank(2) + dim(-1) = new dim(1)
+      dim = vectorType.getRank() + dim;
+    }
+    if (dim > vectorType.getRank()) {
+      emitError(loc, "Reduction dim (" + std::to_string(dim) + ") must be in [0, input rank)");
+      assert(false && "dim must be in [0, input rank)");
+    }
+
+    const int64_t vectorSize = vectorType.getDimSize(dim);
+    const Type elementType = vectorType.getElementType();
+
+    if (clusterSize % vectorType.getShape()[dim] == 0) {
+      // TODO: this can be optimized, now we're simply using shape[dim] number of clusters
+      // TODO: but we should be using all available clusters for all other dims.
+      clusterSize = vectorType.getShape()[dim];
+    }
+
+    // Create the init tensor. Shape is all ones with 1 size smaller than input rank.
+    const SmallVector<int64_t> initSizes = SmallVector<int64_t>(vectorType.getRank() - 1, 1);
+    const Value initTensor = builder.create<tensor::SplatOp>(
+      loc, RankedTensorType::get(initSizes, elementType), ValueRange{init});
+    const Value clusterSizeConst =
       builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(clusterSize));
 
-  if (clusterSize > 1) {
-    const int64_t clusterCount = vectorSize / clusterSize;
-    RankedTensorType intermediateResultType =
-        RankedTensorType::get(SmallVector<int64_t>{clusterCount}, elementType);
-    vector = builder.create<tensor::GenerateOp>(
-        loc, intermediateResultType, ValueRange{},
-        [&](OpBuilder &builder, Location loc, ValueRange indices) {
-          const SmallVector<int64_t> offsets{ShapedType::kDynamic};
-          const SmallVector<int64_t> sizes{clusterSize};
-          const SmallVector<int64_t> strides{1};
+    if (clusterSize > 1) {
+        const int64_t clusterCount = vectorSize / clusterSize;
+        auto tmp = SmallVector<int64_t>(vectorType.getShape());
+        tmp[dim] = clusterCount;
+        RankedTensorType intermediateResultType = RankedTensorType::get(tmp, elementType);
 
-          const Value dynOffset =
-              builder.create<arith::MulIOp>(loc, indices[0], clusterSizeConst);
+        // Aggregate results of partial reductions using tensor.generate and rewrite to inputTensor.
+        // If intermediateResultType[dim] is not 1, we do a second reduction later on.
+        // tensor.generate generates 1 element at a time; should yield a scalar.
+        inputTensor = builder.create<tensor::GenerateOp>(
+            loc, intermediateResultType, ValueRange{},
+            [&](OpBuilder &builder, Location loc, const ValueRange indices) {
+              const SmallVector<int64_t> offsets = SmallVector(vectorType.getRank(), ShapedType::kDynamic);
+              SmallVector<int64_t> sizes = SmallVector<int64_t>(vectorType.getRank(), 1);
+              sizes[dim] = clusterSize;
+              const SmallVector<int64_t> strides = SmallVector<int64_t>(vectorType.getRank(), 1);
 
-          const Type sliceType = tensor::ExtractSliceOp::inferResultType(
-              vectorType, offsets, sizes, strides);
-          const Value slice = builder.create<tensor::ExtractSliceOp>(
-              loc, sliceType, vector, ValueRange{dynOffset}, ValueRange{},
-              ValueRange{}, offsets, sizes, strides);
+              // Offsets == indices except we need to multiply the reduction dim index with the size we're reducing
+              const Value dynOffset = builder.create<arith::MulIOp>(loc, indices[dim], clusterSizeConst);
+              ValueRange dynOffsets = indices;
+              dynOffsets[dim] = dynOffset;
 
-          linalg::ReduceOp sum = builder.create<linalg::ReduceOp>(
-              loc, ValueRange{slice}, ValueRange{initTensor},
-              SmallVector<int64_t>{0},
-              [&](OpBuilder &builder, Location loc, ValueRange args) {
-                const Value result = callback(builder, loc, args[0], args[1]);
-                builder.create<linalg::YieldOp>(loc, result);
-              });
+              const RankedTensorType sliceType = tensor::ExtractSliceOp::inferResultType(vectorType, offsets, sizes, strides);
+              const Value slice = builder.create<tensor::ExtractSliceOp>(loc, sliceType, inputTensor,
+                                                                         dynOffsets, ValueRange{}, ValueRange{},
+                                                                         offsets, sizes, strides);
 
-          builder.create<tensor::YieldOp>(
-              loc, builder.create<tensor::ExtractOp>(loc, sum.getResult(0),
-                                                     ValueRange{}));
-        });
-  }
+              // FIXME: for reduce with e.g. add, initTensor is added for each cluster
+              linalg::ReduceOp intermediate = makeReduceOp(builder, loc, slice, initTensor, dim, callback);
 
-  linalg::ReduceOp sum = builder.create<linalg::ReduceOp>(
-      loc, ValueRange{vector}, ValueRange{initTensor}, SmallVector<int64_t>{0},
-      [&](OpBuilder &builder, Location loc, ValueRange args) {
-        const Value result = callback(builder, loc, args[0], args[1]);
-        builder.create<linalg::YieldOp>(loc, result);
-      });
+              auto constantZero = builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(0));
+              auto extractIndices = SmallVector<Value>(cast<RankedTensorType>(intermediate.getResult(0).getType()).getRank(), constantZero);
 
-  return builder.create<tensor::ExtractOp>(loc, sum.getResult(0), ValueRange{});
+              // Extract scalar result reducing tensor to scalar.
+              builder.create<tensor::YieldOp>(
+                  loc, builder.create<tensor::ExtractOp>(loc, intermediate.getResult(0), ValueRange{extractIndices}));
+            });
+    }
+
+    // If ready to return, process tensor shape to correct shape.
+    if (cast<RankedTensorType>(inputTensor.getType()).getShape()[dim] == 1) {
+      // Reshape (collapse reduction dim) and return.
+      // TODO: check simpler implementation that just drops shape[dim] since it's 1 anyway.
+
+      // auto vec = vectorType.getShape().vec();
+      // vec.erase(vectorType.getShape().vec().begin() + dim);
+      // auto expectedOutputShape = ArrayRef(vec);
+      long outshape[vectorType.getShape().size() - 1];
+      for (size_t i = 0; i < vectorType.getShape().size(); i++) {
+        if (i < dim) {
+          outshape[i] = vectorType.getShape()[i];
+        } else if (i > dim) {
+          outshape[i - 1] = vectorType.getShape()[i];
+        }
+      }
+      auto expectedOutputShape = ArrayRef(outshape, vectorType.getShape().size() - 1);
+
+      // if (expectedOutputShape.empty()) { // Rank == 0
+      //   // Extract scalar result of reducing vector to scalar.
+      //   return builder.create<tensor::ExtractOp>(loc, inputTensor, ValueRange{builder.create<arith::ConstantOp>(loc, builder.getIndexAttr(0))});
+      // }
+
+      auto shape = createMLIRValueFromArrayRef(builder, loc, expectedOutputShape);
+      auto result = builder.create<tensor::ReshapeOp>(loc, RankedTensorType::get(expectedOutputShape, vectorType.getElementType()), inputTensor, shape);
+
+      if (cast<RankedTensorType>(result.getResult().getType()).getRank() == 0) {
+        // Extract scalar result of reducing vector to scalar.
+        return builder.create<tensor::ExtractOp>(loc, result.getResult(), ValueRange{});
+      } else {
+        // Return tensor result as-is
+        return result.getResult();
+      }
+    }
+
+    // Otherwise make a second reduction op (non-tiled)
+    // TODO: this step and the previous `if (shape[dim] == 1)` can/should probably be combined.
+    fprintf(stderr, "--\n(New) input tensor type: ");
+    inputTensor.getType().print(llvm::errs());
+    fprintf(stderr, "\n");
+    // Reduce using linalg builtin reduce op. Also collapses reduced dim for us,
+    // e.g. tensor<10x5xf32> -> tensor<10xf32> when reducing on dim=1
+    linalg::ReduceOp reduceResult = makeReduceOp(builder, loc, inputTensor, initTensor, dim, callback);
+    fprintf(stderr, "Reduce result (dim=%ld): ", dim);
+    reduceResult.getResult(0).getType().print(llvm::errs());
+    fprintf(stderr, "\n");
+
+    if (cast<RankedTensorType>(reduceResult.getResult(0).getType()).getRank() == 0) {
+      // Extract scalar result of reducing vector to scalar.
+      return builder.create<tensor::ExtractOp>(loc, reduceResult.getResult(0), ValueRange{});
+    } else {
+      // Return tensor result as-is
+      return reduceResult.getResult(0);
+    }
 }
 
 Value createVectorReduceAdd(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize) {
+                            const DenseI64ArrayAttr dims, int64_t clusterSize) {
   const Type elementType =
       cast<RankedTensorType>(vector.getType()).getElementType();
   if (FloatType floatType = dyn_cast<FloatType>(elementType)) {
@@ -219,17 +318,17 @@ Value createVectorReduceAdd(OpBuilder &builder, Location loc, Value vector,
         elementType, APFloat::getZero(floatType.getFloatSemantics()));
     const Value init = builder.create<arith::ConstantOp>(loc, zeroAttr);
     return createVectorReduce<arith::AddFOp>(builder, loc, vector, init,
-                                             clusterSize);
+                                             dims, clusterSize);
   } else {
     const TypedAttr zeroAttr = IntegerAttr::get(elementType, 0);
     const Value init = builder.create<arith::ConstantOp>(loc, zeroAttr);
     return createVectorReduce<arith::AddIOp>(builder, loc, vector, init,
-                                             clusterSize);
+                                             dims, clusterSize);
   }
 }
 
 Value createVectorReduceMul(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize) {
+                            const DenseI64ArrayAttr dims, int64_t clusterSize) {
   const Type elementType =
       cast<RankedTensorType>(vector.getType()).getElementType();
   if (FloatType floatType = dyn_cast<FloatType>(elementType)) {
@@ -237,17 +336,17 @@ Value createVectorReduceMul(OpBuilder &builder, Location loc, Value vector,
         FloatAttr::get(elementType, APFloat(floatType.getFloatSemantics(), 1));
     const Value init = builder.create<arith::ConstantOp>(loc, oneAttr);
     return createVectorReduce<arith::MulFOp>(builder, loc, vector, init,
-                                             clusterSize);
+                                             dims, clusterSize);
   } else {
     const TypedAttr oneAttr = IntegerAttr::get(elementType, 1);
     const Value init = builder.create<arith::ConstantOp>(loc, oneAttr);
     return createVectorReduce<arith::MulIOp>(builder, loc, vector, init,
-                                             clusterSize);
+                                             dims, clusterSize);
   }
 }
 
 Value createVectorReduceMin(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize) {
+                            const DenseI64ArrayAttr dims, int64_t clusterSize) {
   const Type elementType =
       cast<RankedTensorType>(vector.getType()).getElementType();
   if (FloatType floatType = dyn_cast<FloatType>(elementType)) {
@@ -255,19 +354,19 @@ Value createVectorReduceMin(OpBuilder &builder, Location loc, Value vector,
         elementType, APFloat::getInf(floatType.getFloatSemantics()));
     const Value init = builder.create<arith::ConstantOp>(loc, maxValAttr);
     return createVectorReduce<arith::MinimumFOp>(builder, loc, vector, init,
-                                                 clusterSize);
+                                                 dims, clusterSize);
   } else {
     const TypedAttr maxValAttr = IntegerAttr::get(
         elementType,
         APInt::getSignedMaxValue(elementType.getIntOrFloatBitWidth()));
     const Value init = builder.create<arith::ConstantOp>(loc, maxValAttr);
     return createVectorReduce<arith::MinSIOp>(builder, loc, vector, init,
-                                              clusterSize);
+                                              dims, clusterSize);
   }
 }
 
 Value createVectorReduceMax(OpBuilder &builder, Location loc, Value vector,
-                            int64_t clusterSize) {
+                            const DenseI64ArrayAttr dims, int64_t clusterSize) {
   const Type elementType =
       cast<RankedTensorType>(vector.getType()).getElementType();
   if (FloatType floatType = dyn_cast<FloatType>(elementType)) {
@@ -275,14 +374,14 @@ Value createVectorReduceMax(OpBuilder &builder, Location loc, Value vector,
         elementType, -APFloat::getInf(floatType.getFloatSemantics()));
     const Value init = builder.create<arith::ConstantOp>(loc, minValAttr);
     return createVectorReduce<arith::MaximumFOp>(builder, loc, vector, init,
-                                                 clusterSize);
+                                                 dims, clusterSize);
   } else {
     const TypedAttr minValAttr = IntegerAttr::get(
         elementType,
         APInt::getSignedMinValue(elementType.getIntOrFloatBitWidth()));
     const Value init = builder.create<arith::ConstantOp>(loc, minValAttr);
     return createVectorReduce<arith::MaxSIOp>(builder, loc, vector, init,
-                                              clusterSize);
+                                              dims, clusterSize);
   }
 }
 

--- a/cinnamon/test/Dialect/Cinm/cinm-ops.mlir
+++ b/cinnamon/test/Dialect/Cinm/cinm-ops.mlir
@@ -9,15 +9,15 @@ func.func @simple(%t0: tensor<6x6xi32>, %t1 : tensor<6xf32> ) {
         %y = cinm.op.sub %t0, %t0: tensor<6x6xi32>
         %y2 = cinm.op.div %t0, %t0: tensor<6x6xi32>
         %y8 = cinm.op.mul %t0, %t0: tensor<6x6xi32>
-        %z = cinm.op.reduce mul (%y): tensor<6x6xi32>
+        %z = cinm.op.reduce mul (%y) { dimensions = array<i64: 0, 1> } : tensor<6x6xi32> -> i32
         %i = arith.addi %z, %z : i32
         %k = arith.constant 62: i64
         %t, %s = cinm.op.topK %k (%y): tensor<6x6xi32> -> tensor<?xi32>, tensor<?xindex>
 
-        %z4 = cinm.op.reduce add (%y): tensor<6x6xi32>
-        %z0 = cinm.op.reduce mul (%y): tensor<6x6xi32>
-        %z1 = cinm.op.reduce max (%t0): tensor<6x6xi32>
-        %q2 = cinm.op.reduce min (%t1): tensor<6xf32>
+        %z4 = cinm.op.reduce add (%y): tensor<6x6xi32> -> tensor<6xi32>
+        %z0 = cinm.op.reduce mul (%y): tensor<6x6xi32> -> tensor<6xi32>
+        %z1 = cinm.op.reduce max (%t0): tensor<6x6xi32> -> tensor<6xi32>
+        %q2 = cinm.op.reduce min (%t1): tensor<6xf32> -> f32
 
         %sqrts = cinm.op.element_wise sqrt (%x): tensor<6x6xi32>
         %exps = cinm.op.element_wise exp (%y): tensor<6x6xi32>

--- a/cinnamon/test/Dialect/Cinm/cinm-tiling.mlir
+++ b/cinnamon/test/Dialect/Cinm/cinm-tiling.mlir
@@ -1,29 +1,21 @@
-// RUN: true
-// skip(RUN): cinm-opt %s --cinm-tiling=reduction-tile-size=16 -split-input-file | FileCheck %s
+// RUN: cinm-opt %s --cinm-tiling=reduction-tile-size=16 -split-input-file | FileCheck %s
 
 
 // CHECK-LABEL: @gemmSquare
-// CHECK-SAME:  (%[[A:.*]]: tensor<1024x1024xi32>, %[[B:.*]]:
-// CHECK:       affine.for %[[i:.*]] = 0 to 1024 step 64
-// CHECK-NEXT:  affine.for %[[j:.*]] = 0 to 1024 step 64
-// CHECK-NEXT:  %[[blockA:.*]] = tensor.extract_slice %[[A]][%[[i]], 0] [64, 1024] [1, 1]
-// CHECK-NEXT:  %[[blockB:.*]] = tensor.extract_slice %[[B]][0, %[[j]]] [1024, 64] [1, 1]
-// CHECK-NEXT:  tensor.generate
-// CHECK-NEXT:  ^{{.*}}(%[[ti:.*]]: index, %[[tj:.*]]: index):
-// CHECK-NEXT:  %[[row:.*]] = tensor.extract_slice %[[blockA]][%[[ti]], 0] [1, 1024] [1, 1]
-// CHECK-NEXT:  %[[col:.*]] = tensor.extract_slice %[[blockB]][0, %[[tj]]] [1024, 1] [1, 1]
+// CHECK-SAME:  (%[[A:.*]]: tensor<1024x1024xi32>, %[[B:.*]]: tensor<1024x1024xi32>) -> tensor<1024x1024xi32> {
+// CHECK:       %[[res0:.*]] = affine.for %[[i:.*]] = 0 to 1024 iter_args({{.*}})
+// CHECK-NEXT:   %[[res1:.*]] = affine.for %[[j:.*]] = 0 to 1024 step 1024 iter_args(%[[acc0:.*]] = {{.*}})
+// CHECK:         %[[res2:.*]] = affine.for %[[k:.*]] = 0 to 1024 step 256 iter_args(%[[acc1:.*]] = {{.*}})
+// CHECK-NEXT:     %[[blockA:.*]] = tensor.extract_slice %[[A]][%[[i]], %[[k]]] [1, 256] [1, 1]
+// CHECK-NEXT:     %[[blockB:.*]] = tensor.extract_slice %[[B]][%[[k]], %[[j]]] [256, 1024] [1, 1]
+// CHECK-NEXT:     %[[res3:.*]] = cinm.op.gemm %[[blockA]], %[[blockB]] plus %[[acc1]] {cinm.notile}
+// CHECK-NEXT:     affine.yield %[[res3]] : tensor<1x1024xi32>
+// CHECK:         %[[ins:.*]] = tensor.insert_slice %[[res2]] into %[[acc0]][%[[i]], %[[j]]]
+// CHECK-NEXT:    affine.yield %[[ins]] : tensor<1024x1024xi32>
+// CHECK:        affine.yield %[[res1]] : tensor<1024x1024xi32>
+// CHECK:       cinm.yield %[[res0]] : tensor<1024x1024xi32>
 
-// CHECK:  		%[[batchedRow:.*]] = tensor.reshape %[[row]](%{{.*}}) : (tensor<1024xi32>, tensor<2xi64>) -> tensor<64x16xi32>
-// CHECK-NEXT:  %[[batchedCol:.*]] = tensor.reshape %[[col]](%{{.*}}) : (tensor<1024xi32>, tensor<2xi64>) -> tensor<64x16xi32>
-// CHECK-NEXT:  %[[stage1:.*]] = linalg.reduce ins(%[[batchedRow]], %[[batchedCol]] : {{.*}}) outs(%{{.*}} : tensor<64xi32>) dimensions = [1]
-// CHECK-NEXT:    (%[[ei:.*]]: i32, %[[ej:.*]]: i32, %[[init:.*]]: i32)
-// CHECK-NEXT:  	%[[mul:.*]] = arith.muli %[[ei]], %[[ej]]
-// CHECK-NEXT:  	%[[add:.*]] = arith.addi %[[mul]], %[[init]]
-// CHECK-NEXT:  	linalg.yield %[[add]]
-
-// CHECK:       linalg.reduce ins(%[[stage1]] : tensor<64xi32>)
-
-func.func @gemmSquare(%a: tensor<1024x1024xi32>, %b: tensor<1024x1024xi32>) -> tensor<1024x1024xi32>{
+func.func @gemmSquare(%a: tensor<1024x1024xi32>, %b: tensor<1024x1024xi32>) -> tensor<1024x1024xi32> {
 	%res = cinm.compute -> tensor<1024x1024xi32> {
 		%d = cinm.op.gemm %a, %b : (tensor<1024x1024xi32>, tensor<1024x1024xi32>) -> tensor<1024x1024xi32>
 		cinm.yield %d: tensor<1024x1024xi32>
@@ -47,6 +39,23 @@ func.func @gemv(%a: tensor<1024x1024xi32>, %b: tensor<1024xi32>) -> tensor<1024x
 // -----
 
 // CHECK-LABEL: @max
+// CHECK-SAME:  (%[[input:.*]]: tensor<1024xi32>) -> i32
+// CHECK-NEXT:  %[[res:.*]] = cinm.compute -> i32 {
+// CHECK:       %[[gen:.*]] = tensor.generate {
+// CHECK-NEXT:  ^{{.*}}(%[[idx:.*]]: {{.*}}):
+// CHECK-NEXT:  %[[idxOffset:.*]] = arith.muli %[[idx]]
+// CHECK-NEXT:       %[[extracted:.*]] = tensor.extract_slice %[[input]][%[[idx]]] [1024] [1]
+// CHECK-NEXT:  %[[reduce:.*]] = linalg.reduce ins(%[[extracted]] : {{.*}}) outs({{.*}}) dimensions = [0]
+// CHECK-NEXT:    (%[[in:.*]]: {{.*}}, %[[acc:.*]]: {{.*}})
+// CHECK-NEXT:       %[[res0:.*]] = arith.maxsi %[[in]], %[[acc]]
+// CHECK-NEXT:       linalg.yield %[[res0]]
+
+// CHECK:       %[[extracted0:.*]] = tensor.extract %[[reduce]][] : tensor<i32>
+// CHECK-NEXT:  tensor.yield %[[extracted0]]
+
+// CHECK:       %[[reshaped:.*]] = tensor.reshape %[[gen]]({{.*}})
+// CHECK-NEXT:  %[[extracted1:.*]] = tensor.extract %[[reshaped]][]
+// CHECK-NEXT:  cinm.yield %[[extracted1]]
 
 func.func @max(%a: tensor<1024xi32>) -> i32 {
 	%res = cinm.compute -> i32 {

--- a/cinnamon/test/Dialect/Cinm/cinm-tiling.mlir
+++ b/cinnamon/test/Dialect/Cinm/cinm-tiling.mlir
@@ -50,7 +50,7 @@ func.func @gemv(%a: tensor<1024x1024xi32>, %b: tensor<1024xi32>) -> tensor<1024x
 
 func.func @max(%a: tensor<1024xi32>) -> i32 {
 	%res = cinm.compute -> i32 {
-		%d = cinm.op.reduce max (%a): tensor<1024xi32>
+		%d = cinm.op.reduce max (%a): tensor<1024xi32> -> i32
 		cinm.yield %d : i32
 	}
 	return %res: i32


### PR DESCRIPTION
A more flexible reduce implementation supporting a user-defined reduction dimension, open to extension for reduction along multiple dimensions. Allows indexing from the back with a negative dim.

Tiling implementation is quite messy, this could probably be improved before merging. I feel like somehow the linalg.reduce op can be exploited for e.g. inferring shapes, but I haven't been able to do this yet.

I updated the gemm tiling test by 'fixing' what's tested. Also, the reduce tiling is tested.