### PR TITLE
build: fix CMAKE_MODULE_PATH for add_subdirectory support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.22)
 
 # Add custom modules to the search path.
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 project(cinm-mlir
     VERSION     0.2.0


### PR DESCRIPTION
**Problem**: CMakeLists.txt uses _${CMAKE_SOURCE_DIR}/cmake_ for the module path. When included via _add_subdirectory()_, this points to the parent project, causing errors like _Unknown CMake command "mlir_gen_ir"_. 
**Solution**: Changed to _${CMAKE_CURRENT_SOURCE_DIR}/cmake_. This resolves the module directory relative to Cinnamon.